### PR TITLE
DDO-386 add monitoring

### DIFF
--- a/import-service/gae-monitoring.tf
+++ b/import-service/gae-monitoring.tf
@@ -1,8 +1,8 @@
 module "gae_monitoring" {
-  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/stackdriver/gae-monitoring?ref=gae-monitoring-0.0.1-tf-0.12"
+  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/stackdriver/gae-monitoring?ref=gae-monitoring-0.0.2-tf-0.12"
   providers = {
     google.target = google.target
   }
-  service_name     = var.service
+  service_name     = "importservice-${var.env}"
   gae_host_project = var.import_service_google_project
 }

--- a/import-service/gae-monitoring.tf
+++ b/import-service/gae-monitoring.tf
@@ -1,0 +1,8 @@
+module "gae_monitoring" {
+  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/stackdriver/gae-monitoring?ref=gae-monitoring-0.0.1-tf-0.12"
+  providers = {
+    google.target = google.target
+  }
+  service_name     = var.service
+  gae_host_project = var.import_service_google_project
+}


### PR DESCRIPTION
This pr adds in standard monitoring policies for GAE applications via stackdriver. The policies will be created in a stackdriver workspace hosted in the same gcp project as import service. 

More information about what these policies monitoring can be found [here](https://github.com/broadinstitute/terraform-shared/blob/master/terraform-modules/stackdriver/gae-monitoring/README.md)