### PR TITLE
DDO-889-1 Support private google access

### DIFF
--- a/import-service/firewall.tf
+++ b/import-service/firewall.tf
@@ -92,6 +92,18 @@ resource "google_app_engine_firewall_rule" "k8s_egress_firewall" {
   source_range = "${local.egress_ips[count.index]}"
 }
 
+# This is needed due to details of google's internal networking between gae and gke
+# This is not a default allow all traffic rule. In this context 0.0.0.0
+# enables Private Google Access which is how gke communicates with gae
+# internally. More information: https://cloud.google.com/vpc/docs/configure-private-google-access
+resource "google_app_engine_firewall_rule" "gke_gae_vpc_firewall" {
+  project      = google_app_engine_application.gae_import_service.project
+  priority     = 1050
+  action       = "ALLOW"
+  description  = "gcp internal network from gke to gae"
+  source_range = "0.0.0.0"
+}
+
 # default-deny firewall rule
 resource "google_app_engine_firewall_rule" "firewall_default_deny" {
   project = google_app_engine_application.gae_import_service.project


### PR DESCRIPTION
In order for GKE services to communicate with GAE apps. The GAE firewall must allow google private access. 
to do this `0.0.0.0` must be whitelisted in the app engine firewall. With out this rule, gke services will not
be able to communicate with app-engine. 

This is not a default allow all traffic policy. This a quirk of google
internal networking that allows resources with ephemeral ips such as gke nodes to communicate with app-engine.
[more info](https://cloud.google.com/vpc/docs/configure-private-google-access)﻿
