### PR TITLE
use later google-project, cloudsql-mysql modules [AJ-133]

### DIFF
--- a/import-service/db.tf
+++ b/import-service/db.tf
@@ -7,7 +7,7 @@ resource "random_id" "mysql-root-password" {
 }
 
 module "mysql" {
-  source        = "github.com/broadinstitute/terraform-shared.git//terraform-modules/cloudsql-mysql?ref=cloudsql-mysql-0.2.3-tf-0.12"
+  source        = "github.com/broadinstitute/terraform-shared.git//terraform-modules/cloudsql-mysql?ref=cloudsql-mysql-0.2.4"
 
   providers = {
     google.target =  google.target,

--- a/import-service/google-project.tf
+++ b/import-service/google-project.tf
@@ -1,5 +1,5 @@
 module "import-service-project" {
-  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/google-project?ref=da_AJ-133_deprecatedSyntax"
+  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/google-project?ref=google-project-0.0.4-tf-0.12"
 
   project_name = local.import_service_google_project
   folder_id = var.import_service_google_project_folder_id

--- a/import-service/google-project.tf
+++ b/import-service/google-project.tf
@@ -1,5 +1,5 @@
 module "import-service-project" {
-  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/google-project?ref=google-project-0.0.3-tf-0.12"
+  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/google-project?ref=da_AJ-133_deprecatedSyntax"
 
   project_name = local.import_service_google_project
   folder_id = var.import_service_google_project_folder_id


### PR DESCRIPTION
This PR points at changes to the `google-project` module in broadinstitute/terraform-shared#172, as well as a point update to the `cloudsql-mysql` module from 0.2.3 to 0.2.4.

The `atlantis plan` for this can be seen in broadinstitute/terraform-ap-deployments#686.