### PR TITLE
output of terraform 0.13upgrade [AJ-415]

### DIFF
--- a/import-service/versions.tf
+++ b/import-service/versions.tf
@@ -1,22 +1,22 @@
 terraform {
   required_providers {
     google = {
-      source = "registry.terraform.io/hashicorp/google"
+      source = "hashicorp/google"
     }
     google-beta = {
-      source = "registry.terraform.io/hashicorp/google-beta"
+      source = "hashicorp/google-beta"
     }
     http = {
-      source = "registry.terraform.io/hashicorp/http"
+      source = "hashicorp/http"
     }
     null = {
-      source = "registry.terraform.io/hashicorp/null"
+      source = "hashicorp/null"
     }
     random = {
-      source = "registry.terraform.io/hashicorp/random"
+      source = "hashicorp/random"
     }
     vault = {
-      source = "registry.terraform.io/hashicorp/vault"
+      source = "hashicorp/vault"
     }
   }
   required_version = ">= 0.13"

--- a/import-service/versions.tf
+++ b/import-service/versions.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+    google-beta = {
+      source = "hashicorp/google-beta"
+    }
+    http = {
+      source = "hashicorp/http"
+    }
+    null = {
+      source = "hashicorp/null"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+    vault = {
+      source = "hashicorp/vault"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/import-service/versions.tf
+++ b/import-service/versions.tf
@@ -1,22 +1,22 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "registry.terraform.io/hashicorp/google"
     }
     google-beta = {
-      source = "hashicorp/google-beta"
+      source = "registry.terraform.io/hashicorp/google-beta"
     }
     http = {
-      source = "hashicorp/http"
+      source = "registry.terraform.io/hashicorp/http"
     }
     null = {
-      source = "hashicorp/null"
+      source = "registry.terraform.io/hashicorp/null"
     }
     random = {
-      source = "hashicorp/random"
+      source = "registry.terraform.io/hashicorp/random"
     }
     vault = {
-      source = "hashicorp/vault"
+      source = "registry.terraform.io/hashicorp/vault"
     }
   }
   required_version = ">= 0.13"


### PR DESCRIPTION
This PR makes import_service_terraform compatible with Terraform 0.13.

See https://www.terraform.io/language/upgrade-guides/0-13 for doc on the upgrade. The relevant section in that page is "Explicit Provider Source Locations," which details that we must now specify a source address for each provider in use. I've done that in `versions.tf`; I generated that file by running `terraform 0.13upgrade` locally.

See https://github.com/broadinstitute/terraform-ap-deployments/pull/689 for the `atlantis plan` output of these changes.

part of AJ-415 but does not complete that ticket.