### PR TITLE
Terraform 1.2.2

### DIFF
--- a/import-service/db.tf
+++ b/import-service/db.tf
@@ -8,7 +8,9 @@ resource "random_id" "mysql-root-password" {
 
 module "mysql" {
   source        = "github.com/broadinstitute/terraform-shared.git//terraform-modules/cloudsql-mysql?ref=da_api-services-1.0.0"
-
+  providers = {
+    google.target = google
+  }
   project       = module.import-service-project.project_name
   cloudsql_name = "import-service-db"
   cloudsql_database_name = "isvc"

--- a/import-service/db.tf
+++ b/import-service/db.tf
@@ -9,10 +9,6 @@ resource "random_id" "mysql-root-password" {
 module "mysql" {
   source        = "github.com/broadinstitute/terraform-shared.git//terraform-modules/cloudsql-mysql?ref=cloudsql-mysql-0.2.4"
 
-  providers = {
-    google.target =  google.target,
-    google.dns =  google.target
-  }
   project       = module.import-service-project.project_name
   cloudsql_name = "import-service-db"
   cloudsql_database_name = "isvc"

--- a/import-service/db.tf
+++ b/import-service/db.tf
@@ -7,7 +7,7 @@ resource "random_id" "mysql-root-password" {
 }
 
 module "mysql" {
-  source        = "github.com/broadinstitute/terraform-shared.git//terraform-modules/cloudsql-mysql?ref=cloudsql-mysql-0.2.4"
+  source        = "github.com/broadinstitute/terraform-shared.git//terraform-modules/cloudsql-mysql?ref=da_api-services-1.0.0"
 
   project       = module.import-service-project.project_name
   cloudsql_name = "import-service-db"

--- a/import-service/db.tf
+++ b/import-service/db.tf
@@ -7,7 +7,7 @@ resource "random_id" "mysql-root-password" {
 }
 
 module "mysql" {
-  source        = "github.com/broadinstitute/terraform-shared.git//terraform-modules/cloudsql-mysql?ref=da_api-services-1.0.0"
+  source        = "github.com/broadinstitute/terraform-shared.git//terraform-modules/cloudsql-mysql?ref=cloudsql-mysql-1.0.0"
   providers = {
     google.target = google
   }

--- a/import-service/gae-monitoring.tf
+++ b/import-service/gae-monitoring.tf
@@ -1,8 +1,5 @@
 module "gae_monitoring" {
   source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/stackdriver/gae-monitoring?ref=gae-monitoring-0.0.2-tf-0.12"
-  providers = {
-    google.target = google.target
-  }
   service_name     = "importservice-${var.env}"
   gae_host_project = var.import_service_google_project
 }

--- a/import-service/gae-monitoring.tf
+++ b/import-service/gae-monitoring.tf
@@ -1,5 +1,5 @@
 module "gae_monitoring" {
-  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/stackdriver/gae-monitoring?ref=da_api-services-1.0.0"
+  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/stackdriver/gae-monitoring?ref=gae-monitoring-1.0.0"
   providers = {
     google.target = google
   }

--- a/import-service/gae-monitoring.tf
+++ b/import-service/gae-monitoring.tf
@@ -1,5 +1,5 @@
 module "gae_monitoring" {
-  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/stackdriver/gae-monitoring?ref=gae-monitoring-0.0.2-tf-0.12"
+  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/stackdriver/gae-monitoring?ref=da_api-services-1.0.0"
   service_name     = "importservice-${var.env}"
   gae_host_project = var.import_service_google_project
 }

--- a/import-service/gae-monitoring.tf
+++ b/import-service/gae-monitoring.tf
@@ -1,5 +1,8 @@
 module "gae_monitoring" {
   source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/stackdriver/gae-monitoring?ref=da_api-services-1.0.0"
+  providers = {
+    google.target = google
+  }
   service_name     = "importservice-${var.env}"
   gae_host_project = var.import_service_google_project
 }

--- a/import-service/google-project.tf
+++ b/import-service/google-project.tf
@@ -1,6 +1,8 @@
 module "import-service-project" {
   source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/google-project?ref=da_api-services-1.0.0"
-
+  providers = {
+    google.target = google
+  }
   project_name = local.import_service_google_project
   folder_id = var.import_service_google_project_folder_id
   billing_account_id = var.billing_account_id

--- a/import-service/google-project.tf
+++ b/import-service/google-project.tf
@@ -1,5 +1,5 @@
 module "import-service-project" {
-  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/google-project?ref=google-project-0.0.4-tf-0.12"
+  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/google-project?ref=da_api-services-1.0.0"
 
   project_name = local.import_service_google_project
   folder_id = var.import_service_google_project_folder_id

--- a/import-service/google-project.tf
+++ b/import-service/google-project.tf
@@ -1,5 +1,5 @@
 module "import-service-project" {
-  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/google-project?ref=da_api-services-1.0.0"
+  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/google-project?ref=google-project-1.0.0"
   providers = {
     google.target = google
   }

--- a/import-service/google-project.tf
+++ b/import-service/google-project.tf
@@ -56,11 +56,6 @@ module "import-service-project" {
     sa_name = "deployer"
     sa_project = "" // defaults to the created project
   }]
-
-  providers = {
-    google.target = google.target
-    vault = vault
-  }
 }
 
 locals {

--- a/import-service/provider.tf
+++ b/import-service/provider.tf
@@ -1,7 +1,0 @@
-provider "google" {
-  alias = "target"
-}
-
-provider "google-beta" {
-  alias = "target"
-}

--- a/import-service/versions.tf
+++ b/import-service/versions.tf
@@ -2,9 +2,15 @@ terraform {
   required_providers {
     google = {
       source = "hashicorp/google"
+      configuration_aliases = [
+        google.target,
+      ]
     }
     google-beta = {
       source = "hashicorp/google-beta"
+      configuration_aliases = [
+        google-beta.target,
+      ]
     }
     http = {
       source = "hashicorp/http"

--- a/import-service/versions.tf
+++ b/import-service/versions.tf
@@ -25,5 +25,5 @@ terraform {
       source = "hashicorp/vault"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 1.0"
 }


### PR DESCRIPTION
Supports Terraform 1.x compatibility for import service. Code changes relate to provider definitions.

Parent PR, showing the `atlantis plan` output:
* https://github.com/broadinstitute/terraform-ap-deployments/pull/691

Child PR, showing the changes to referenced modules:
* https://github.com/broadinstitute/terraform-shared/pull/173