### PR TITLE
limit IAM roles [AJ-415, AJ-458]

### DIFF
--- a/import-service/google-project.tf
+++ b/import-service/google-project.tf
@@ -66,7 +66,8 @@ module "import-service-project" {
     sa_name = "deployer"
     sa_project = "" // defaults to the created project
   },{
-    sa_role = "roles/appEngineScheduleCreator"
+    # Note that custom roles must be of the format [projects|organizations]/{parent-name}/roles/{role-name}.
+    sa_role = "projects/${module.import-service-project.project_name}/roles/${google_project_iam_custom_role.cloud-scheduler-appengine-custom-role.role_id}"
     sa_name = "deployer"
     sa_project = "" // defaults to the created project
   }]

--- a/import-service/google-project.tf
+++ b/import-service/google-project.tf
@@ -1,14 +1,14 @@
 # Custom IAM role to be used by the deployer SA. This custom role allows creating/updating cloud scheduler
 # jobs during App Engine deployment via cron.yaml.
 resource "google_project_iam_custom_role" "cloud-scheduler-appengine-custom-role" {
-  role_id     = "appEngineScheduleCreator"
-  title       = "App Engine Schedule Creator"
-  description = "Allows creation of Cloud Scheduler schedules during App Engine deployment"
-  permissions = ["cloudscheduler.jobs.create", "cloudscheduler.jobs.delete", "cloudscheduler.jobs.enable",
+  role_id     = "appEngineDeploymentEnabler"
+  title       = "App Engine Deployment Enabler"
+  description = "Additional permissions needed to deploy and enable new App Engine versions. Allows creation of Cloud Scheduler schedules and routing of traffic to the new version."
+  permissions = ["appengine.services.update", "appengine.versions.update",
+                  "cloudscheduler.jobs.create", "cloudscheduler.jobs.delete", "cloudscheduler.jobs.enable",
                   "cloudscheduler.jobs.fullView", "cloudscheduler.jobs.get", "cloudscheduler.jobs.list",
                   "cloudscheduler.jobs.update", "cloudscheduler.locations.get", "cloudscheduler.locations.list"]
 }
-
 
 module "import-service-project" {
   source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/google-project?ref=google-project-1.0.0"
@@ -55,10 +55,6 @@ module "import-service-project" {
     sa_project = "" // defaults to the created project
   },{
     sa_role = "roles/appengine.deployer"
-    sa_name = "deployer"
-    sa_project = "" // defaults to the created project
-  },{
-    sa_role = "roles/appengine.serviceAdmin"
     sa_name = "deployer"
     sa_project = "" // defaults to the created project
   },{

--- a/import-service/google-project.tf
+++ b/import-service/google-project.tf
@@ -34,7 +34,7 @@ module "import-service-project" {
   }]
 
   service_accounts_to_grant_by_name_and_project = [{
-    sa_role = "roles/pubsub.admin"
+    sa_role = "roles/pubsub.editor"
     sa_name = "import-service"
     sa_project = "" // defaults to the created project
   },{

--- a/import-service/google-project.tf
+++ b/import-service/google-project.tf
@@ -1,3 +1,15 @@
+# Custom IAM role to be used by the deployer SA. This custom role allows creating/updating cloud scheduler
+# jobs during App Engine deployment via cron.yaml.
+resource "google_project_iam_custom_role" "cloud-scheduler-appengine-custom-role" {
+  role_id     = "appEngineScheduleCreator"
+  title       = "App Engine Schedule Creator"
+  description = "Allows creation of Cloud Scheduler schedules during App Engine deployment"
+  permissions = ["cloudscheduler.jobs.create", "cloudscheduler.jobs.delete", "cloudscheduler.jobs.enable",
+                  "cloudscheduler.jobs.fullView", "cloudscheduler.jobs.get", "cloudscheduler.jobs.list",
+                  "cloudscheduler.jobs.update", "cloudscheduler.locations.get", "cloudscheduler.locations.list"]
+}
+
+
 module "import-service-project" {
   source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/google-project?ref=google-project-1.0.0"
   providers = {
@@ -54,7 +66,7 @@ module "import-service-project" {
     sa_name = "deployer"
     sa_project = "" // defaults to the created project
   },{
-    sa_role = "roles/cloudscheduler.admin"
+    sa_role = "roles/appEngineScheduleCreator"
     sa_name = "deployer"
     sa_project = "" // defaults to the created project
   }]


### PR DESCRIPTION
To satisfy AJ-415 and AJ-458:
1. `import-service@` SA changes from using the `pubsub.admin` to the `pubsub.editor` role
2. `deployer@` SA changes to using a new custom role with the necessary Cloud Scheduler and App Engine permissions instead of `cloudscheduler.admin` and `appengine.serviceAdmin`. Note that this SA still uses `appengine.deployer`; the new custom role contains the permissions necessary above and beyond `appengine.deployer`.

Parent PR showing `atlantis plan`:
* https://github.com/broadinstitute/terraform-ap-deployments/pull/694