### PR TITLE
key rotation for import-service deployer SA [AJ-654]

### DIFF
--- a/import-service/google-project.tf
+++ b/import-service/google-project.tf
@@ -35,7 +35,7 @@ module "import-service-project" {
   # key-rotation policy for service accounts
   # note this requires the terraform to be run regularly
   resource "time_rotating" "sa_key_rotation_policy" {
-    rotation_days = 30
+    rotation_days = 75 // compliance requirement: 90 days
   }
 
   // create deployer SA

--- a/import-service/google-project.tf
+++ b/import-service/google-project.tf
@@ -32,22 +32,24 @@ resource "google_project_iam_custom_role" "cloud-scheduler-appengine-custom-role
     }
   }
 
+  // TODO: uncomment when ready to handle the import-service SA outside of terraform-modules
   // create import-service SA
-  resource "google_service_account" "sa_import-service" {
-    account_id   = "import-service"
-    display_name = "import-service"
-    project      = local.import_service_google_project
-  }
+  # resource "google_service_account" "sa_import-service" {
+  #   account_id   = "import-service"
+  #   display_name = "import-service"
+  #   project      = local.import_service_google_project
+  # }
 
+  // TODO: uncomment when ready to handle the import-service SA outside of terraform-modules
   // create key for import-service SA, pointing at rotation policy
   // ** only create the key in qa and dev ** since the key is only needed for BEEs
-  resource "google_service_account_key" "sa_key_import-service" {
-    count = var.env == "qa" || var.env == "dev" ? 1 : 0
-    service_account_id = "import-service"
-    keepers = {
-      rotation_time = time_rotating.sa_key_rotation_policy.rotation_rfc3339
-    }
-  }
+  # resource "google_service_account_key" "sa_key_import-service" {
+  #   count = var.env == "qa" || var.env == "dev" ? 1 : 0
+  #   service_account_id = "import-service"
+  #   keepers = {
+  #     rotation_time = time_rotating.sa_key_rotation_policy.rotation_rfc3339
+  #   }
+  # }
 
   // N.B we save the keys for deployer and import-service SAs to Vault in vault.tf, not here
 
@@ -70,6 +72,14 @@ module "import-service-project" {
     "sqladmin.googleapis.com",
     "cloudscheduler.googleapis.com",
     "containerscanning.googleapis.com"
+  ]
+
+  // TODO: delete when ready to handle the import-service SA outside of terraform-modules
+  service_accounts_to_create_with_keys = [
+    {
+      sa_name = "import-service"
+      key_vault_path = "${var.vault_root}/${local.vault_path}/import-service-account.json"
+    }
   ]
 
   roles_to_grant_by_email_and_type = [{

--- a/import-service/google-project.tf
+++ b/import-service/google-project.tf
@@ -12,46 +12,48 @@ resource "google_project_iam_custom_role" "cloud-scheduler-appengine-custom-role
 }
 
 # key-rotation policy for service accounts
-  # note this requires the terraform to be run regularly
-  resource "time_rotating" "sa_key_rotation_policy" {
-    rotation_days = 75 // compliance requirement: 90 days
+# note this requires the terraform to be run regularly
+resource "time_rotating" "sa_key_rotation_policy" {
+  rotation_days = 75 # compliance requirement: 90 days
+}
+
+# create deployer SA
+resource "google_service_account" "sa_deployer" {
+  account_id   = "deployer"
+  display_name = "deployer"
+  description  = "Used to deploy code to App Engine"
+  project      = local.import_service_google_project
+}
+
+# create key for deployer SA, pointing at rotation policy
+resource "google_service_account_key" "sa_key_deployer" {
+  service_account_id = "deployer"
+  keepers = {
+    rotation_time = time_rotating.sa_key_rotation_policy.rotation_rfc3339
   }
+}
 
-  // create deployer SA
-  resource "google_service_account" "sa_deployer" {
-    account_id   = "deployer"
-    display_name = "deployer"
-    project      = local.import_service_google_project
-  }
+# TODO: uncomment when ready to handle the import-service SA outside of terraform-modules
+# create import-service SA
+# resource "google_service_account" "sa_import-service" {
+#   account_id   = "import-service"
+#   display_name = "import-service"
+#   description  = "Used within the Import Service GAE app and by BEEs to run the app"
+#   project      = local.import_service_google_project
+# }
 
-  // create key for deployer SA, pointing at rotation policy
-  resource "google_service_account_key" "sa_key_deployer" {
-    service_account_id = "deployer"
-    keepers = {
-      rotation_time = time_rotating.sa_key_rotation_policy.rotation_rfc3339
-    }
-  }
+# TODO: uncomment when ready to handle the import-service SA outside of terraform-modules
+# create key for import-service SA, pointing at rotation policy
+# ** only create the key in qa and dev ** since the key is only needed for BEEs
+# resource "google_service_account_key" "sa_key_import-service" {
+#   count = var.env == "qa" || var.env == "dev" ? 1 : 0
+#   service_account_id = "import-service"
+#   keepers = {
+#     rotation_time = time_rotating.sa_key_rotation_policy.rotation_rfc3339
+#   }
+# }
 
-  // TODO: uncomment when ready to handle the import-service SA outside of terraform-modules
-  // create import-service SA
-  # resource "google_service_account" "sa_import-service" {
-  #   account_id   = "import-service"
-  #   display_name = "import-service"
-  #   project      = local.import_service_google_project
-  # }
-
-  // TODO: uncomment when ready to handle the import-service SA outside of terraform-modules
-  // create key for import-service SA, pointing at rotation policy
-  // ** only create the key in qa and dev ** since the key is only needed for BEEs
-  # resource "google_service_account_key" "sa_key_import-service" {
-  #   count = var.env == "qa" || var.env == "dev" ? 1 : 0
-  #   service_account_id = "import-service"
-  #   keepers = {
-  #     rotation_time = time_rotating.sa_key_rotation_policy.rotation_rfc3339
-  #   }
-  # }
-
-  // N.B we save the keys for deployer and import-service SAs to Vault in vault.tf, not here
+# N.B we save the keys for deployer and import-service SAs to Vault in vault.tf, not here
 
 module "import-service-project" {
   source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/google-project?ref=google-project-1.0.0"

--- a/import-service/google-project.tf
+++ b/import-service/google-project.tf
@@ -11,28 +11,7 @@ resource "google_project_iam_custom_role" "cloud-scheduler-appengine-custom-role
                   "cloudscheduler.jobs.update", "cloudscheduler.locations.get", "cloudscheduler.locations.list"]
 }
 
-module "import-service-project" {
-  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/google-project?ref=google-project-1.0.0"
-  providers = {
-    google.target = google
-  }
-  project_name = local.import_service_google_project
-  folder_id = var.import_service_google_project_folder_id
-  billing_account_id = var.billing_account_id
-  apis_to_enable = [
-    "logging.googleapis.com",
-    "monitoring.googleapis.com",
-    "appengine.googleapis.com",
-    "cloudbuild.googleapis.com",
-    "pubsub.googleapis.com",
-    "storage-component.googleapis.com",
-    "iamcredentials.googleapis.com",
-    "sqladmin.googleapis.com",
-    "cloudscheduler.googleapis.com",
-    "containerscanning.googleapis.com"
-  ]
-
-  # key-rotation policy for service accounts
+# key-rotation policy for service accounts
   # note this requires the terraform to be run regularly
   resource "time_rotating" "sa_key_rotation_policy" {
     rotation_days = 75 // compliance requirement: 90 days
@@ -71,6 +50,27 @@ module "import-service-project" {
   }
 
   // N.B we save the keys for deployer and import-service SAs to Vault in vault.tf, not here
+
+module "import-service-project" {
+  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/google-project?ref=google-project-1.0.0"
+  providers = {
+    google.target = google
+  }
+  project_name = local.import_service_google_project
+  folder_id = var.import_service_google_project_folder_id
+  billing_account_id = var.billing_account_id
+  apis_to_enable = [
+    "logging.googleapis.com",
+    "monitoring.googleapis.com",
+    "appengine.googleapis.com",
+    "cloudbuild.googleapis.com",
+    "pubsub.googleapis.com",
+    "storage-component.googleapis.com",
+    "iamcredentials.googleapis.com",
+    "sqladmin.googleapis.com",
+    "cloudscheduler.googleapis.com",
+    "containerscanning.googleapis.com"
+  ]
 
   roles_to_grant_by_email_and_type = [{
     email = local.terraform_sa_email

--- a/import-service/vault.tf
+++ b/import-service/vault.tf
@@ -39,3 +39,15 @@ resource "vault_generic_secret" "app-database-instance-name" {
 }
 EOT
 }
+
+resource "vault_generic_secret" "sa_key_deployer" {
+  path = "${var.vault_root}/${local.vault_path}/deployer.json"
+  data_json = base64decode(google_service_account_key.sa_key_deployer.private_key)
+}
+
+// ** this SA key only exists in qa and dev ** since the key is only needed for BEEs
+resource "vault_generic_secret" "sa_key_import-service" {
+  count = var.env == "qa" || var.env == "dev" ? 1 : 0
+  path = "${var.vault_root}/${local.vault_path}/import-service-account.json"
+  data_json = base64decode(google_service_account_key.sa_key_deployer.private_key)
+}

--- a/import-service/vault.tf
+++ b/import-service/vault.tf
@@ -45,9 +45,10 @@ resource "vault_generic_secret" "sa_key_deployer" {
   data_json = base64decode(google_service_account_key.sa_key_deployer.private_key)
 }
 
+// TODO: uncomment when ready to handle the import-service SA outside of terraform-modules
 // ** this SA key only exists in qa and dev ** since the key is only needed for BEEs
-resource "vault_generic_secret" "sa_key_import-service" {
-  count = var.env == "qa" || var.env == "dev" ? 1 : 0
-  path = "${var.vault_root}/${local.vault_path}/import-service-account.json"
-  data_json = base64decode(google_service_account_key.sa_key_deployer.private_key)
-}
+# resource "vault_generic_secret" "sa_key_import-service" {
+#   count = var.env == "qa" || var.env == "dev" ? 1 : 0
+#   path = "${var.vault_root}/${local.vault_path}/import-service-account.json"
+#   data_json = base64decode(google_service_account_key.sa_key_deployer.private_key)
+# }

--- a/import-service/vault.tf
+++ b/import-service/vault.tf
@@ -45,8 +45,8 @@ resource "vault_generic_secret" "sa_key_deployer" {
   data_json = base64decode(google_service_account_key.sa_key_deployer.private_key)
 }
 
-// TODO: uncomment when ready to handle the import-service SA outside of terraform-modules
-// ** this SA key only exists in qa and dev ** since the key is only needed for BEEs
+# TODO: uncomment when ready to handle the import-service SA outside of terraform-modules
+# ** this SA key only exists in qa and dev ** since the key is only needed for BEEs
 # resource "vault_generic_secret" "sa_key_import-service" {
 #   count = var.env == "qa" || var.env == "dev" ? 1 : 0
 #   path = "${var.vault_root}/${local.vault_path}/import-service-account.json"


### PR DESCRIPTION
`atlantis plan` results at broadinstitute/terraform-ap-deployments#863

In this PR:
* handle SA creation and SA key creation for the `deployer` SA directly in `import_service_terraform`, instead of relying on `terraform-modules`
* configure SA keys to rotate after 75 days (well before the 90-day compliance requirement)
* do not attempt any changes to the `import-service` SA yet ~only create the import-service SA key in dev and qa; these are the only envs that need it~

Note that by moving the SA and key creation without any use of `terraform mv` or a `moved` block, I expect these SAs and keys to be deleted and re-created. Getting `terraform mv` or `moved` to work has proven to be a rathole and does not seem worth the effort.

Deleting and re-creating the `deployer` SA, key, and Vault secret should be no problem. We only use the deployer SA to perform deployments of import-service. This is an offline operation and not involved at all in user requests.

Deleting and re-creating the `import-service` SA, key, and Vault secret will require Import Service to be redeployed/restarted in order to pick up the new credentials. This SA is used during GCS and Pub/Sub operations. Because of this impact, we must handhold/coordinate when we apply this Terraform to prod so as to avoid user impact.

Due to the potential problems with deleting and re-creating the `import-service` SA, I have updated this PR to only deal with the `deployer` SA. Once we get this PR deployed through all envs and see it is working, I'll turn around and tackle the `import-service` SA with my newfound knowledge and confidence.
