### PR TITLE
AJ-973: reduce retention 90d -> 14d

### DIFF
--- a/import-service/bucket.tf
+++ b/import-service/bucket.tf
@@ -5,7 +5,7 @@ resource "google_storage_bucket" "batchupsert_bucket" {
   location = "US"
   lifecycle_rule {
     condition {
-      age = 90
+      age = 14
     }
     action {
       type = "Delete"


### PR DESCRIPTION
This PR changes the lifecycle rule on the `import-service-batchupsert-${ENV}` buckets from "delete after 90 days" to "delete after 14 days".

We don't have any specific compliance requirements for retention of these files. We retain them to assist with debugging/support of issues. Let's reduce that debugging window to 14 days and save on our GCS spend.

Atlantis plan at https://github.com/broadinstitute/terraform-ap-deployments/pull/1186.